### PR TITLE
External req update: 

### DIFF
--- a/index.js
+++ b/index.js
@@ -316,7 +316,6 @@ class Connector {
     }
 
 
-
     joinWithBase(url) {
         return Connector.joinUrl(this._baseUrl, url);
     }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ class Connector {
         // this._runningRequest = false;
     }
 
-
     //base url
     set baseUrl(url) {
         this._baseUrl = url
@@ -27,7 +26,6 @@ class Connector {
         return this._baseUrl
     }
 
-
     //headers
     set headers(obj) {
         this._headers = obj;
@@ -36,8 +34,6 @@ class Connector {
     get header() {
         return this._headers;
     }
-
-
 
     //request start
     set onRequestStart(fn) {
@@ -61,9 +57,6 @@ class Connector {
         }, this._onRequestStartDelay)
     }
 
-
-
-
     //request end
     set onRequestEnd(fn) {
         this._onRequestEnd = fn;
@@ -76,10 +69,6 @@ class Connector {
             return await this._onRequestEnd();
         }
     }
-
-
-
-
 
     // status wise error handlers
     async _handle404(response, options) {
@@ -194,7 +183,6 @@ class Connector {
         this._errorHandler = fn;
     }
 
-
     //success handler
     async _successHandler(response, options) {
         return await response.json()
@@ -202,7 +190,6 @@ class Connector {
     set successHandler(fn) {
         this._successHandler = fn;
     }
-
 
     // root response handler
     async handleResponse(response, options) {
@@ -224,9 +211,6 @@ class Connector {
             }
         }
     }
-
-
-
 
     //request methods
 
@@ -314,7 +298,6 @@ class Connector {
         });
         return this.handleResponse(response, options)
     }
-
 
     joinWithBase(url) {
         return Connector.joinUrl(this._baseUrl, url);

--- a/index.js
+++ b/index.js
@@ -232,8 +232,12 @@ class Connector {
 
     async get(url, options = {}) {
         await this.handleRequestStart(options);
+
+        const requestUrl = options?.externalUrl ? url : this.joinWithBase(url); // If we need to send a request to an external URL
+        // we don't want to join with base
+        
         try {
-            const response = await fetch(this.joinWithBase(url), {
+            const response = await fetch(requestUrl, {
                 headers: {
                     ...this._headers,
                     ...{
@@ -262,11 +266,15 @@ class Connector {
                 ...options.headers,
             }
         }
+        
         if (options.removeContentType) delete reqOptions.headers["content-type"]
 
-        const response = await fetch(this.joinWithBase(url), reqOptions);
+        const requestUrl = options?.externalUrl ? url : this.joinWithBase(url); // If we need to send a request to an external URL
+        // we don't want to join with base. 
+        const response = await fetch(requestUrl, reqOptions);
         return this.handleResponse(response, options)
     }
+
     async put(url, payload, options = {}) {
         await this.handleRequestStart(options);
         const reqOptions = {
@@ -284,13 +292,17 @@ class Connector {
 
         if (options.removeContentType) delete reqOptions.headers["content-type"]
 
-        const response = await fetch(this.joinWithBase(url), reqOptions);
+        const requestUrl = options?.externalUrl ? url : this.joinWithBase(url); // If we need to send a request to an external URL
+        // we don't want to join with base. 
+        const response = await fetch(requestUrl, reqOptions);
         return this.handleResponse(response, options)
     }
 
     async delete(url, options = {}) {
         await this.handleRequestStart(options);
-        const response = await fetch(this.joinWithBase(url), {
+        const requestUrl = options?.externalUrl ? url : this.joinWithBase(url); // If we need to send a request to an external URL
+        // we don't want to join with base. (not necessary on delete request but a library should have all available options) 
+        const response = await fetch(requestUrl, {
             method: "DELETE",
             headers: {
                 ...this._headers,


### PR DESCRIPTION
Now we are able to make CRUD operations  to a external URL (Third party ), without creating a new instance. 

We just need to set "externalUrl" property in request options then the existing instance won't join that Url to the base, it will make the request directly to that third party Url. 